### PR TITLE
Fix adding multiple attachments

### DIFF
--- a/.github/README.adoc
+++ b/.github/README.adoc
@@ -51,14 +51,14 @@ let originalPdfData = try testResource(name: "simple_pdf", extension: "pdf")
 let toBeAttachedData = try testResource(name: "somedata", extension: "")
 
 // Parse the PDF data
-let originalPdfDataString = String(data: originalPdfData, encoding: .ascii)!.utf8
+let originalPdfDataString = String(data: originalPdfData, encoding: .isoLatin1)!.utf8
 let parsedPdfDocument = try PDFDocument.PDFDocumentParserPrinter().parse(originalPdfDataString)
 
 // Render the attachment data before appending
 let renderedAttachmentData = try parsedPdfDocument.append(
-    attachment: .init(filename: "attachmentFilename🧸", content: toBeAttachedData),
-    startObj:  originalPdfData.count
-)
+    attachments: [.init(filename: "attachmentFilename🧸", content: toBeAttachedData)],
+    startObj: originalPdfData.count
+).first!
 
 // Add the rendered attachment data to the original PDF data
 let pdfWithAttachmentData = originalPdfData + renderedAttachmentData
@@ -72,7 +72,7 @@ You can also extract attachments from a PDF:
 
 [source,swift]
 ----
-let pdfWithAttachmentDataString = String(data: pdfWithAttachmentData, encoding: .ascii)!.utf8
+let pdfWithAttachmentDataString = String(data: pdfWithAttachmentData, encoding: .isoLatin1)!.utf8
 let parsedPdfWithAttachment = try PDFDocument.PDFDocumentParserPrinter().parse(pdfWithAttachmentDataString)
 let attachments = try parsedPdfWithAttachment.allAttachments()
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-22
 
 DEPENDENCIES

--- a/Sources/GemPDFKit/PDFAttachment.swift
+++ b/Sources/GemPDFKit/PDFAttachment.swift
@@ -115,4 +115,5 @@ enum PDFDocumentError: Error, Equatable {
     case missingEFFileReference
     case fileObjectWithoutData
     case failedToCreateStringFromPrintedObject
+    case failedToCreateAttachmentPayloadData
 }

--- a/Tests/GemPDFKitTests/PDFDocumentAppendTests.swift
+++ b/Tests/GemPDFKitTests/PDFDocumentAppendTests.swift
@@ -29,20 +29,57 @@ final class PDFDocumentAppendTests: XCTestCase {
     }
 
     func testParsingTestDocument1() throws {
+        // Parse the original PDF data and data to be attached
+        let originalPdfData = try testResource(name: "simple_pdf", extension: "pdf")
+        let toBeAttachedData = try testResource(name: "somedata", extension: "")
+        
+        // Parse the PDF data
+        let originalPdfDataString = String(data: originalPdfData, encoding: .isoLatin1)!.utf8
+        let parsedPdfDocument = try PDFDocument.PDFDocumentParserPrinter().parse(originalPdfDataString)
+        
+        // Render the attachment data before appending
+        let renderedAttachmentData = try parsedPdfDocument.append(
+            attachment: .init(filename: "attachmentFilename🧸", content: toBeAttachedData),
+            startObj: originalPdfData.count
+        )
+        
+        // Add the rendered attachment data to the original PDF data
+        let pdfWithAttachmentData = originalPdfData + renderedAttachmentData
+        
+        // Write the data to your system
+        let outputPath = outputResourceURL(name: "output", extension: "pdf")
+        try pdfWithAttachmentData.write(to: outputPath)
+        
+        // This is for manual validation:
+        let compare = outputResourceURL(name: "compare", extension: "pdf")
+        try renderedAttachmentData.write(to: compare)
+        
+        // Extract the test data
+        // tag::extractAttachmentFromPdf[]
+        let pdfWithAttachmentDataString = String(data: pdfWithAttachmentData, encoding: .isoLatin1)!.utf8
+        let parsedPdfWithAttachment = try PDFDocument.PDFDocumentParserPrinter().parse(pdfWithAttachmentDataString)
+        let attachments = try parsedPdfWithAttachment.allAttachments()
+        
+        expect(attachments.count).to(equal(1)) // ✅
+        expect(attachments.first?.content).to(equal(toBeAttachedData)) // ✅
+        // end::extractAttachmentFromPdf[]
+    }
+
+    func testParsingTestDocument2() throws {
         // tag::parseAndAttachToPdf[]
         // Parse the original PDF data and data to be attached
         let originalPdfData = try testResource(name: "simple_pdf", extension: "pdf")
         let toBeAttachedData = try testResource(name: "somedata", extension: "")
 
         // Parse the PDF data
-        let originalPdfDataString = String(data: originalPdfData, encoding: .ascii)!.utf8
+        let originalPdfDataString = String(data: originalPdfData, encoding: .isoLatin1)!.utf8
         let parsedPdfDocument = try PDFDocument.PDFDocumentParserPrinter().parse(originalPdfDataString)
 
         // Render the attachment data before appending
         let renderedAttachmentData = try parsedPdfDocument.append(
-            attachment: .init(filename: "attachmentFilename🧸", content: toBeAttachedData),
+            attachments: [.init(filename: "attachmentFilename🧸", content: toBeAttachedData)],
             startObj: originalPdfData.count
-        )
+        ).first!
 
         // Add the rendered attachment data to the original PDF data
         let pdfWithAttachmentData = originalPdfData + renderedAttachmentData
@@ -57,13 +94,53 @@ final class PDFDocumentAppendTests: XCTestCase {
         try renderedAttachmentData.write(to: compare)
 
         // Extract the test data
-        // tag::extractAttachmentFromPdf[]
-        let pdfWithAttachmentDataString = String(data: pdfWithAttachmentData, encoding: .ascii)!.utf8
+        let pdfWithAttachmentDataString = String(data: pdfWithAttachmentData, encoding: .isoLatin1)!.utf8
         let parsedPdfWithAttachment = try PDFDocument.PDFDocumentParserPrinter().parse(pdfWithAttachmentDataString)
         let attachments = try parsedPdfWithAttachment.allAttachments()
 
         expect(attachments.count).to(equal(1)) // ✅
         expect(attachments.first?.content).to(equal(toBeAttachedData)) // ✅
-        // end::extractAttachmentFromPdf[]
+    }
+
+    func testParsingTestDocument3() throws {
+        // Parse the original PDF data and data to be attached
+        let originalPdfData = try testResource(name: "simple_pdf", extension: "pdf")
+        let toBeAttachedData = try testResource(name: "somedata", extension: "")
+        let toBeAttachedData2 = try testResource(name: "somedata2", extension: "")
+
+        // Parse the PDF data
+        let originalPdfDataString = String(data: originalPdfData, encoding: .isoLatin1)!.utf8
+        let parsedPdfDocument = try PDFDocument.PDFDocumentParserPrinter().parse(originalPdfDataString)
+
+        // Render the attachment data before appending
+        let renderedAttachmentData = try parsedPdfDocument.append(attachments: [
+            .init(filename: "a_somedata", content: toBeAttachedData),
+            .init(filename: "b_somedata", content: toBeAttachedData2),
+        ], startObj: originalPdfData.count)
+
+        // Add the rendered attachment data to the original PDF data
+        let pdfWithAttachmentData = originalPdfData + renderedAttachmentData.reduce(Data(), +)
+
+        // Write the data to your system
+        let outputPath = outputResourceURL(name: "output", extension: "pdf")
+        try pdfWithAttachmentData.write(to: outputPath)
+
+        // This is for manual validation:
+        for (key, singleEntry) in renderedAttachmentData.enumerated() {
+            let compare = outputResourceURL(name: "compare\(key)", extension: "pdf")
+            try singleEntry.write(to: compare)
+        }
+
+        // Extract the test data
+        let pdfWithAttachmentDataString = String(data: pdfWithAttachmentData, encoding: .isoLatin1)!.utf8
+        let parsedPdfWithAttachment = try PDFDocument.PDFDocumentParserPrinter().parse(pdfWithAttachmentDataString)
+        let attachments = try parsedPdfWithAttachment.allAttachments()
+
+        expect(attachments.count).to(equal(2)) // ✅
+        expect({
+            attachments.sorted { left, right in
+                left.filename < right.filename
+            }.map(\.content)
+        }).to(equal([toBeAttachedData, toBeAttachedData2])) // ✅
     }
 }

--- a/Tests/GemPDFKitTests/PDFDocumentPartTests.swift
+++ b/Tests/GemPDFKitTests/PDFDocumentPartTests.swift
@@ -92,7 +92,7 @@ final class PDFDocumentPartTests: XCTestCase {
 
     func testParsingDocumentPart1() throws {
         let data = try testResource(name: "document_part", extension: "data")
-        let inputString = String(data: data, encoding: .ascii)!
+        let inputString = String(data: data, encoding: .isoLatin1)!
 
         let result = try PDFDocumentPart.PDFDocumentPartParserPrinter().parse(inputString)
 

--- a/Tests/GemPDFKitTests/PDFDocumentTests.swift
+++ b/Tests/GemPDFKitTests/PDFDocumentTests.swift
@@ -92,7 +92,7 @@ final class PDFDocumentTests: XCTestCase {
 
     func testParsingTestDocument1() throws {
         let data = try testResource(name: "simple_pdf", extension: "pdf")
-        let inputString = String(data: data, encoding: .ascii)!.utf8
+        let inputString = String(data: data, encoding: .isoLatin1)!.utf8
 
         let result = try PDFDocument.PDFDocumentParserPrinter().parse(inputString)
 
@@ -104,7 +104,7 @@ final class PDFDocumentTests: XCTestCase {
 
     func testParsingTestDocument2() throws {
         let data = try testResource(name: "simple_pdf_out", extension: "pdf")
-        let inputString = String(data: data, encoding: .ascii)!.utf8
+        let inputString = String(data: data, encoding: .isoLatin1)!.utf8
 
         let result = try PDFDocument.PDFDocumentParserPrinter().parse(inputString)
 

--- a/Tests/GemPDFKitTests/TestData/somedata2
+++ b/Tests/GemPDFKitTests/TestData/somedata2
@@ -1,0 +1,1 @@
+more_testdata


### PR DESCRIPTION
A single file attachement worked fine, but adding multiple attachments did not show all attachements but the last one. This fixes this issue by adding additional references to all previous attachments within each new attachment.

Also fixes iOS 16 encoding issues within the tests